### PR TITLE
Fix how response headers are processed

### DIFF
--- a/lambda/convert-http-method.py
+++ b/lambda/convert-http-method.py
@@ -15,7 +15,7 @@ GRAPHQL_ENDPOINT = '/queries'
 def http_request(endpoint, method='GET', headers={}, data=None):
     req = urllib.request.Request(endpoint, method=method, headers=headers, data=data)
     res = urllib.request.urlopen(req)
-    res_code = res.getcode()
+    res_code = res.status
     res_body = res.read().decode('utf-8')
     res_headers = response_headers(res)
 

--- a/lambda/convert-http-method.py
+++ b/lambda/convert-http-method.py
@@ -35,7 +35,7 @@ def response_headers(res):
     }
 
 
-# Remove disallowd headers on lambda@edge
+# Remove disallowed headers on lambda@edge
 def remove_disallowed_headers(headers):
     return {
         key: val

--- a/lambda/convert-http-method.py
+++ b/lambda/convert-http-method.py
@@ -1,5 +1,6 @@
 import urllib.request
 import base64
+from disallowed_headers import is_blacklisted_or_readonly_header
 
 # Max cacheable size on each header.
 CACHE_PAYLOAD_SIZE_LIMIT = 1783
@@ -21,7 +22,7 @@ def http_request(endpoint, method='GET', headers={}, data=None):
 
     return {
         'status': res_code,
-        'headers': res_headers,
+        'headers': remove_disallowed_headers(res_headers),
         'body': res_body
     }
 
@@ -31,6 +32,15 @@ def response_headers(res):
     return {
         key.lower(): [{'key': key, 'value': val}]
         for key, val in res.headers.items()
+    }
+
+
+# Remove disallowd headers on lambda@edge
+def remove_disallowed_headers(headers):
+    return {
+        key: val
+        for key, val in headers.items()
+        if not is_blacklisted_or_readonly_header(key)
     }
 
 

--- a/lambda/convert-http-method.py
+++ b/lambda/convert-http-method.py
@@ -28,9 +28,10 @@ def http_request(endpoint, method='GET', headers={}, data=None):
 
 # Convert urllib response header to cloudfront response header format.
 def response_headers(res):
-    headers_raw = dict(res.info())
-    headers = list(map(lambda x: { x: { 'key': x, 'value': headers_raw[x] } }, headers_raw.keys()))
-    return headers
+    return {
+        key.lower(): [{'key': key, 'value': val}]
+        for key, val in res.headers.items()
+    }
 
 
 # Split request payload

--- a/lambda/convert-http-method.py
+++ b/lambda/convert-http-method.py
@@ -10,6 +10,7 @@ NUM_SPLIT_MAX = 5
 # GraphQL endpoint
 GRAPHQL_ENDPOINT = '/queries'
 
+
 # Execute http request
 def http_request(endpoint, method='GET', headers={}, data=None):
     req = urllib.request.Request(endpoint, method=method, headers=headers, data=data)
@@ -24,11 +25,13 @@ def http_request(endpoint, method='GET', headers={}, data=None):
         'body': res_body
     }
 
+
 # Convert urllib response header to cloudfront response header format.
 def response_headers(res):
     headers_raw = dict(res.info())
     headers = list(map(lambda x: { x: { 'key': x, 'value': headers_raw[x] } }, headers_raw.keys()))
     return headers
+
 
 # Split request payload
 def split_payload(data):
@@ -49,6 +52,7 @@ def split_payload(data):
             payloads.append('')
 
     return payloads
+
 
 # Lambda@Edge handler
 def handler(event, context):

--- a/lambda/convert-http-method.py
+++ b/lambda/convert-http-method.py
@@ -1,9 +1,5 @@
 import urllib.request
-import urllib.parse
-import json
 import base64
-from urllib.parse import parse_qs
-from urllib.parse import quote
 
 # Max cacheable size on each header.
 CACHE_PAYLOAD_SIZE_LIMIT = 1783

--- a/lambda/disallowed_headers.py
+++ b/lambda/disallowed_headers.py
@@ -1,0 +1,64 @@
+import re
+
+# Disallowed headers on edge functions
+# https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-functions-restrictions.html#edge-function-restrictions-all
+_BLACKLISTED_HEADERS = [
+    'Connection',
+    'Expect',
+    'Keep-Alive',
+    'Proxy-Authenticate',
+    'Proxy-Authorization',
+    'Proxy-Connection',
+    'Trailer',
+    'Upgrade',
+    'X-Accel-Buffering',
+    'X-Accel-Charset',
+    'X-Accel-Limit-Rate',
+    'X-Accel-Redirect',
+    # X-Amz-Cf-*,
+    'X-Amzn-Auth',
+    'X-Amzn-Cf-Billing',
+    'X-Amzn-Cf-Id',
+    'X-Amzn-Cf-Xff',
+    'X-Amzn-Errortype',
+    'X-Amzn-Fle-Profile',
+    'X-Amzn-Header-Count',
+    'X-Amzn-Header-Order',
+    'X-Amzn-Lambda-Integration-Tag',
+    'X-Amzn-RequestId',
+    'X-Cache',
+    # X-Edge-*,
+    'X-Forwarded-Proto',
+    'X-Real-IP'
+]
+
+blacklisted_headers_lower = [header.lower() for header in _BLACKLISTED_HEADERS]
+
+
+def is_blacklisted_header(header_name):
+    pattern = re.compile(r'^x-(amz-cf|edge)-+')
+    return header_name.lower() in blacklisted_headers_lower or pattern.match(header_name.lower())
+
+
+# Read-only headers in origin request events (Lambda@Edge only)
+# https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-functions-restrictions.html#edge-function-restrictions-all
+_READONLY_HEADERS = [
+    'Accept-Encoding',
+    'Content-Length',
+    'If-Modified-Since',
+    'If-None-Match',
+    'If-Range',
+    'If-Unmodified-Since',
+    'Transfer-Encoding',
+    'Via'
+]
+
+readonly_headers_lower = [header.lower() for header in _READONLY_HEADERS]
+
+
+def is_readonly_header(header_name):
+    return header_name.lower() in readonly_headers_lower
+
+
+def is_blacklisted_or_readonly_header(header_name):
+    return is_blacklisted_header(header_name) or is_readonly_header(header_name)


### PR DESCRIPTION
*Issue #, if available:*
#7 

*Description of changes:*
I have fixed the Lambda function code for the following three points.

1. removed the statement importing unused modules according to flake8, and added two blank lines before the statement defining the function according to pycodestyle.

2. Fixed the response_headers function to return a dictionary with the correct structure.

3. Added `is_blacklisted_or_readonly_header` function to remove headers that cannot be used by Lambda@Edge.

The first is a coding style fix and does not affect the behavior of the Lambda function code. See the documentation below for details.
- https://flake8.pycqa.org/en/6.1.0/user/error-codes.html#error-violation-codes
- https://pycodestyle.pycqa.org/en/stable/intro.html?highlight=e302#error-codes

The second fixes the bug reported in #7. Users of this sample do not expect to lose response headers set at the origin. 

The third is a new feature made necessary by the bug fix. The response headers set at the origin may contain disallowed headers on Lambda@Edge(e.g., `Content-Length`).The response headers for GET requests issued by Lambda@Edge also contain disallowed headers on Lambda@Edge (e.g., `X-Cache`, `X-Amz-Cf-*`). If Lambda@Edge returns a response containing such headers to CloudFront, CloudFront will return an error.
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-functions-restrictions.html

>Disallowed headers
The following HTTP headers are not exposed to edge functions, and functions can't add them. If your function adds one of these headers, it fails CloudFront validation and CloudFront returns HTTP status code 502 (Bad Gateway) to the viewer.

>Read-only headers
The following headers are read-only. Your function can read them and use them as input to the function logic, but it can't change the values. If your function adds or edits a read-only header, the request fails CloudFront validation and CloudFront returns HTTP status code 502 (Bad Gateway) to the viewer.

Therefore, such headers must be removed before Lambda@Edge returns a response to CloudFront.

The `is_blacklisted_or_readonly_header` function and the list of disallowed headers on Lambda@Edge are written in a dedicated module so that the readability of the handler function is not compromised.

If you deploy the project containing the changes in this PR and run the reproduction command described in #7, you will see that the response headers set at the origin are not lost.
```shell
$ (curl --include  -XPOST -d '{"query":"xxx"}' -H "Content-Type:application/json" "http://${ALB_DNS_NAME}/queries" && echo) > alb_res.txt
$ (curl --include  -XPOST -d '{"query":"xxx"}' -H "Content-Type:application/json" "http://${CF_DNS_NAME}/queries" && echo) > cf_res.txt
$ diff -u alb_res.txt cf_res.txt
--- alb_res.txt 2023-08-26 11:26:22.546083003 +0000
+++ cf_res.txt  2023-08-26 11:26:30.858104747 +0000
@@ -1,10 +1,15 @@
 HTTP/1.1 200 OK
-Date: Sat, 26 Aug 2023 11:26:22 GMT
 Content-Type: text/html;charset=utf-8
 Content-Length: 8
 Connection: keep-alive
+Server: CloudFront
+Date: Sat, 26 Aug 2023 11:26:30 GMT
 X-XSS-Protection: 1; mode=block
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
+X-Cache: Miss from cloudfront
+Via: 1.1 32c5b7040885724e78019cc31f0ef3e8.cloudfront.net (CloudFront)
+X-Amz-Cf-Pop: IAD89-C2
+X-Amz-Cf-Id: U5S0HdsTTDa13OreOAmbsIEGr3R7HFStbGMGyby7PktoANGJwzbp8A==
 
-qu2AL8AT
+6N0M1jmW
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
